### PR TITLE
rename the crate to `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # This is NOT an official Rust project but since most code will come from
 # the rust-lang/rust repo it makes sense to use this author.
 authors = ["The Rust Project Developers"]
-name = "steed"
+name = "std"
 version = "0.1.0"
 
 [dependencies.ralloc]

--- a/examples/create.rs
+++ b/examples/create.rs
@@ -2,10 +2,10 @@
 #![no_main]
 
 #[macro_use]
-extern crate steed;
+extern crate std;
 
-use steed::fs::File;
-use steed::io::Write;
+use std::fs::File;
+use std::io::Write;
 
 #[no_mangle]
 pub fn main() -> i32 {

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -2,10 +2,10 @@
 #![no_main]
 
 #[macro_use]
-extern crate steed;
+extern crate std;
 
-use steed::io;
-use steed::io::{Read, Write};
+use std::io;
+use std::io::{Read, Write};
 
 #[no_mangle]
 pub fn main() -> i32 {

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 #[macro_use]
-extern crate steed;
+extern crate std;
 
 #[no_mangle]
 pub fn main() -> i32 {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -2,10 +2,10 @@
 #![no_main]
 
 #[macro_use]
-extern crate steed;
+extern crate std;
 
-use steed::io;
-use steed::io::Write;
+use std::io;
+use std::io::Write;
 
 #[no_mangle]
 pub fn main() -> i32 {

--- a/examples/instant.rs
+++ b/examples/instant.rs
@@ -2,9 +2,9 @@
 #![no_main]
 
 #[macro_use]
-extern crate steed;
+extern crate std;
 
-use steed::time::Instant;
+use std::time::Instant;
 
 #[no_mangle]
 pub fn main() -> i32 {

--- a/examples/one.rs
+++ b/examples/one.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate steed;
+extern crate std;
 
 #[no_mangle]
 pub fn main() -> i32 {

--- a/examples/open.rs
+++ b/examples/open.rs
@@ -2,11 +2,11 @@
 #![no_main]
 
 #[macro_use]
-extern crate steed;
+extern crate std;
 
-use steed::fs::File;
-use steed::io::{Read, Write};
-use steed::io;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::io;
 
 #[no_mangle]
 pub fn main() -> i32 {

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate steed;
+extern crate std;
 
 #[no_mangle]
 pub fn main() -> i32 {

--- a/examples/stderr.rs
+++ b/examples/stderr.rs
@@ -2,10 +2,10 @@
 #![no_main]
 
 #[macro_use]
-extern crate steed;
+extern crate std;
 
-use steed::io;
-use steed::io::Write;
+use std::io;
+use std::io::Write;
 
 #[no_mangle]
 pub fn main() -> i32 {

--- a/examples/system-time.rs
+++ b/examples/system-time.rs
@@ -2,9 +2,9 @@
 #![no_main]
 
 #[macro_use]
-extern crate steed;
+extern crate std;
 
-use steed::time::SystemTime;
+use std::time::SystemTime;
 
 #[no_mangle]
 pub fn main() -> i32 {

--- a/examples/vec.rs
+++ b/examples/vec.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 #[macro_use]
-extern crate steed;
+extern crate std;
 
 #[no_mangle]
 pub fn main() -> i32 {

--- a/examples/zero.rs
+++ b/examples/zero.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate steed;
+extern crate std;
 
 #[no_mangle]
 pub fn main() -> i32 {


### PR DESCRIPTION
so we can use this crate as drop in replacement for the real `std` using
Xargo

cc #20