### PR TITLE
use custom docker images for i686, x86_64 and armv7hf

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,11 @@
 [build]
 xargo = true
+
+[target.armv7-unknown-linux-gnueabihf]
+image = "japaric/arm-linux"
+
+[target.i686-unknown-linux-gnu]
+image = "japaric/i686-linux"
+
+[target.x86_64-unknown-linux-gnu]
+image = "japaric/x86_64-linux"

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,0 +1,18 @@
+set -ex
+
+run() {
+    docker build \
+           -t japaric/$1:${TRAVIS_TAG:-latest} \
+           -f docker/${1}/Dockerfile \
+           docker
+}
+
+if [ -z $1 ]; then
+    for t in `ls docker/`; do
+        if [ -d docker/$t ]; then
+            run $t
+        fi
+    done
+else
+    run $1
+fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -18,30 +18,6 @@ main() {
     done
 
     for example in ${examples[@]}; do
-        # NOTE linker errors
-        if [ $TARGET = armv7-unknown-linux-gnueabihf ] && [ $example = open ]; then
-            continue
-        fi
-        if [ $TARGET = armv7-unknown-linux-gnueabihf ] && [ $example = vec ]; then
-            continue
-        fi
-
-        if [ $TARGET = i686-unknown-linux-gnu ] && [ $example = vec ]; then
-            continue
-        fi
-
-        if [ $TARGET = i686-unknown-linux-gnu ] && [ $example = instant ]; then
-            continue
-        fi
-
-        if [ $TARGET = armv7-unknown-linux-gnueabihf ] && [ $example = instant ]; then
-            continue
-        fi
-
-        if [ $TARGET = x86_64-unknown-linux-gnu ] && [ $example = vec ]; then
-            continue
-        fi
-
         cross run --target $TARGET --example $example --release
     done
 }

--- a/docker/arm-linux/Dockerfile
+++ b/docker/arm-linux/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gcc \
+    libc6-dev && \
+    curl -LSfs http://japaric.github.io/trust/install.sh | \
+    sh -s -- --git japaric/xargo --tag v0.3.3 --target x86_64-unknown-linux-gnu --to /usr/bin && \
+    apt-get purge --auto-remove -y curl
+
+COPY qemu.sh /
+RUN apt-get install -y --no-install-recommends \
+    gcc-arm-linux-gnueabihf && \
+    bash /qemu.sh 2.8.0 arm
+
+ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+    QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
+    RUST_TEST_THREADS=1

--- a/docker/i686-linux/Dockerfile
+++ b/docker/i686-linux/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gcc \
+    libc6-dev && \
+    curl -LSfs http://japaric.github.io/trust/install.sh | \
+    sh -s -- --git japaric/xargo --tag v0.3.3 --target x86_64-unknown-linux-gnu --to /usr/bin && \
+    apt-get purge --auto-remove -y curl
+
+RUN apt-get install -y --no-install-recommends \
+    gcc-multilib

--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -1,0 +1,56 @@
+set -ex
+
+main() {
+    local arch=$2 \
+          td=$(mktemp -d) \
+          version=$1
+
+    local dependencies=(
+        autoconf
+        automake
+        bzip2
+        curl
+        g++
+        libglib2.0-dev
+        libtool
+        make
+        pkg-config
+        zlib1g-dev
+    )
+
+    apt-get update
+    local purge_list=()
+    for dep in ${dependencies[@]}; do
+        dpkg -L $dep || (
+            apt-get install --no-install-recommends -y $dep &&
+                purge_list+=( $dep )
+        )
+    done
+
+    pushd $td
+
+    curl http://wiki.qemu-project.org/download/qemu-$version.tar.bz2 | \
+        tar --strip-components=1 -xj
+    ./configure \
+        --disable-kvm \
+        --disable-vnc \
+        --enable-user \
+        --static \
+        --target-list=$arch-linux-user
+    nice make -j$(nproc)
+    make install
+
+    # HACK the binfmt_misc interpreter we'll use expects the QEMU binary to be
+    # in /usr/bin. Create an appropriate symlink
+    ln -s /usr/local/bin/qemu-$arch /usr/bin/qemu-$arch-static
+
+    # Clean up
+    apt-get purge --auto-remove -y ${purge_list[@]}
+
+    popd
+
+    rm -rf $td
+    rm $0
+}
+
+main "${@}"

--- a/docker/x86_64-linux/Dockerfile
+++ b/docker/x86_64-linux/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gcc \
+    libc6-dev && \
+    curl -LSfs http://japaric.github.io/trust/install.sh | \
+    sh -s -- --git japaric/xargo --tag v0.3.3 --target x86_64-unknown-linux-gnu --to /usr/bin && \
+    apt-get purge --auto-remove -y curl


### PR DESCRIPTION
these ship with more recent linkers that solve the linker errors we have
been seeing

closes #15