### PR TITLE
re-enable debug assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,5 @@ git = "https://github.com/japaric/syscall.rs"
 [features]
 default = ["ralloc"]
 
-[profile.dev]
-debug_assertions = false
-
 [profile.release]
 lto = true


### PR DESCRIPTION
where are now using a different allocator to run our test suite so we no longer
need to disable debug-assertions