### PR TITLE
bare bones test crate

### DIFF
--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -29,7 +29,7 @@ main() {
 
     pushd $td
 
-    curl http://wiki.qemu-project.org/download/qemu-$version.tar.bz2 | \
+    curl http://download.qemu-project.org/qemu-$version.tar.bz2 | \
         tar --strip-components=1 -xj
     ./configure \
         --disable-kvm \

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+authors = ["Jorge Aparicio <japaricious@gmail.com>"]
+name = "test"
+version = "0.1.0"

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,0 +1,49 @@
+pub mod test {
+    pub use ShouldPanic;
+}
+
+pub struct TestDesc {
+    pub ignore: bool,
+    pub name: StaticTestName,
+    pub should_panic: ShouldPanic,
+}
+
+pub struct TestDescAndFn {
+    pub desc: TestDesc,
+    pub testfn: StaticTestFn,
+}
+
+pub struct StaticTestFn(pub fn());
+pub struct StaticTestName(pub &'static str);
+
+pub enum ShouldPanic {
+    No,
+    Yes,
+}
+
+pub fn test_main_static(tests: &'static [TestDescAndFn]) {
+    let n = tests.len();
+
+    println!("Running {} test{}", n, if n == 1 { "" } else { "s" });
+
+    let mut passed = 0;
+    let mut ignored = 0;
+    for test in tests {
+        match test.desc.should_panic {
+            ShouldPanic::No => {
+                print!("test {} ... ", test.desc.name.0);
+                test.testfn.0();
+                println!("ok");
+                passed += 1;
+            }
+            ShouldPanic::Yes => {
+                println!("test {} ... ignored", test.desc.name.0);
+                ignored += 1;
+            }
+        }
+    }
+
+    println!("\ntest result: ok. {} passed; 0 failed; {} ignored; 0 measured",
+             passed,
+             ignored);
+}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -24,6 +24,10 @@ pub struct StaticTestName(pub &'static str);
 
 pub struct Bencher {}
 
+impl Bencher {
+    pub fn iter<T, F>(&mut self, _: F) where F: FnMut() -> T {}
+}
+
 #[derive(Clone, Copy)]
 pub enum ShouldPanic {
     No,

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -30,6 +30,8 @@ pub enum ShouldPanic {
     Yes,
 }
 
+pub fn black_box<T>(_: T) {}
+
 pub fn test_main_static(tests: &'static [TestDescAndFn]) {
     let n = tests.len();
 


### PR DESCRIPTION
To get `cargo test` working with `steed`

Limitations:

- No colored output
- No support for `#[bench]`
- `#[should_panic]` tests are ignored
- Tests are run sequentially
- Ignores all command line arguments

How to test your crate against `steed`:

- Modify your Xargo.toml to look like this

``` toml
[dependencies.collections]
[dependencies.rand]

[dependencies.std]
git = "https://github.com/japaric/steed"  # or path
stage = 1

[dependencies.test]
git = "https://github.com/japaric/steed"  # or path
stage = 2
```

- Then use `xargo test` or `cross test`

closes #23

---

I want to check that this enough to test `steed` itself before merging it. Then
in another PR, I'll add testing to CI and start gating on it.