### PR TITLE
Use core::str instead of std_unicode::str

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -256,7 +256,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use cmp;
-use std_unicode::str as core_str;
+use core::str as core_str;
 use error as std_error;
 use fmt;
 use result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 #![feature(slice_concat_ext)]
 #![feature(slice_patterns)]
 #![feature(staged_api)]
+#![feature(str_internals)]
 #![feature(try_from)]
 #![feature(unicode)]
 #![feature(unique)]


### PR DESCRIPTION
Fixes a compilation error introduced by https://github.com/rust-lang/rust/pull/40189