### PR TITLE
Fix 'cannot mutably borrow immutable field' copmpile error

### DIFF
--- a/src/collections/hash/table.rs
+++ b/src/collections/hash/table.rs
@@ -973,7 +973,7 @@ impl<'a, K, V> Iterator for Drain<'a, K, V> {
     fn next(&mut self) -> Option<(SafeHash, K, V)> {
         self.iter.next().map(|bucket| {
             unsafe {
-                (**self.table).size -= 1;
+                (*self.table.as_mut_ptr()).size -= 1;
                 let (k, v) = ptr::read(bucket.pair);
                 (SafeHash { hash: ptr::replace(bucket.hash, EMPTY_BUCKET) }, k, v)
             }


### PR DESCRIPTION
   --> src/collections/hash/table.rs:976:17
    |
976 |                 (**self.table).size -= 1;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^ cannot mutably borrow immutable field

Partially cherry-picks a8f4a1bd984091ffb8f87f9440e2483f94b44a20 from
rust project.