### PR TITLE
[RFC] split platform support in two tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ pass on these platforms:
 
 "Best effort" level of support. Using some features that require architecture
 specific code, like threads, may panic at runtime if the work to support that
-feature has not been done yet (`unimplemented!()`). We don't block PRs if CI
-tests don't pass on these platforms:
+feature has not been done yet (i.e. `unimplemented!()`). We don't block PRs if
+CI tests don't pass on these platforms:
 
 - `mips-unknown-linux-steed`
 
@@ -149,6 +149,11 @@ tests don't pass on these platforms:
 
 <!-- - `sparc64-unknown-linux-steed` -->
 
+We eventually hope to move all targets into the tier 1 but we'll need help from
+people more familiar with the non-x86 architectures. If you'd like to help,
+feel free to contact us on IRC (#rust-steed @ irc.mozilla.org) or via the issue
+tracker, or directly tackle the architecture specific issues, issue tagged with
+e.g. `A-powerpc`, listed on the issue tracker.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,20 @@ $ ls -l hello
 
 ## Supported architectures
 
-`steed` is [continuously tested][ci] on these platforms (using QEMU):
+Turns out that writing architecture specific code is tricky! We were trying to
+provide "if it compiles, it works" level of support for every architecture that
+`std` supports but that stalled development as it's hard to get some features
+working on a bunch of different architectures.
 
-[ci]: https://travis-ci.org/japaric/steed
+So, we have adopted Rust's tier system to unstuck development. Our platform
+support is split in two tiers:
+
+### Tier 1
+
+"If it compiles, it works" level of support. PRs won't land if [CI] tests don't
+pass on these platforms:
+
+[CI]: https://travis-ci.org/japaric/steed
 
 - `aarch64-unknown-linux-steed`
 
@@ -112,6 +123,15 @@ $ ls -l hello
 - `armv7-unknown-linux-steedeabihf`
 
 - `i686-unknown-linux-steed`
+
+- `x86_64-unknown-linux-steed`
+
+### Tier 2
+
+"Best effort" level of support. Using some features that require architecture
+specific code, like threads, may panic at runtime if the work to support that
+feature has not been done yet (`unimplemented!()`). We don't block PRs if CI
+tests don't pass on these platforms:
 
 - `mips-unknown-linux-steed`
 
@@ -129,7 +149,6 @@ $ ls -l hello
 
 <!-- - `sparc64-unknown-linux-steed` -->
 
-- `x86_64-unknown-linux-steed`
 
 ## Usage
 


### PR DESCRIPTION
Some PRs became stalled because they broke some platform or because there was
still work to do to support all the platforms listed in our "Supported
Platforms" section.

Here's a proposal to unstuck those two PRs and development in general:

Let's adopt Rust's tier system.

The TL;DR is that we have tier 1 platforms that must always work (gate PRs on
passing CI) and tier 2 platforms where it's OK to not support all of the API
that tier 1 platforms support (calls to unsupported API result in panics, not
compile errors (\*)), specially architecture specific stuff like threads, until
we get the bandwidth to do the required work.

You can find more details in the README.

(\*) The rationale here is that I expect that raising compile errors instead of
panicking will require way more conditional code (`#[cfg]`s) and thus more
effort.

Thoughts on the idea? If it seems like a good idea, what platforms should be
tier 1?

cc @tbu- @briansmith @anatol