### PR TITLE
default to lld as the linker, update the README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ after_success:
 after_script: set +e
 
 before_cache:
-  - docker history -q japaric/$TARGET:v0.1.8 |
+  - docker history -q japaric/$TARGET:v0.1.10 |
     grep -v \<missing\> |
     xargs docker save |
     gzip > $HOME/docker/$TARGET.tar.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,8 @@ optional = true
 optional = true
 path = "naive_ralloc"
 
-[dependencies.compiler_builtins]
-default-features = false
-features = ["mem"]
-git = "https://github.com/rust-lang-nursery/compiler-builtins"
-
 [features]
-default = ["compiler-builtins", "ralloc"]
-compiler-builtins = ["compiler_builtins/compiler-builtins"]
+default = ["ralloc"]
 
 [profile.release]
 lto = true

--- a/Xargo.std.toml
+++ b/Xargo.std.toml
@@ -6,3 +6,7 @@ rand = {}
 features = ["mem"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 stage = 1
+
+[dependencies.std]
+git = "https://github.com/japaric/steed"
+stage = 2

--- a/Xargo.test.toml
+++ b/Xargo.test.toml
@@ -6,3 +6,11 @@ rand = {}
 features = ["mem"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 stage = 1
+
+[dependencies.std]
+git = "https://github.com/japaric/steed"
+stage = 2
+
+[dependencies.test]
+git = "https://github.com/japaric/steed"
+stage = 3

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -2,7 +2,7 @@ set -ex
 
 run() {
     docker build \
-           -t japaric/${1}:v0.1.9 \
+           -t japaric/${1}:v0.1.10 \
            -f docker/${1}/Dockerfile \
            docker
 }

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -8,7 +8,7 @@ main() {
         sh -s -- \
            --force \
            --git japaric/cross \
-           --tag v0.1.9 \
+           --tag v0.1.10 \
            --target x86_64-unknown-linux-musl
 }
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,9 +1,6 @@
 set -ex
 
 main() {
-    curl https://sh.rustup.rs -sSf | \
-        sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION
-
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- \
            --force \

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -30,7 +30,7 @@ main() {
         cross run \
               --target $TARGET \
               --no-default-features \
-              --features "compiler-builtins naive_ralloc" \
+              --features naive_ralloc \
               --example $example
     done
 
@@ -38,7 +38,7 @@ main() {
         cross run \
               --target $TARGET \
               --no-default-features \
-              --features "compiler-builtins naive_ralloc" \
+              --features naive_ralloc \
               --example $example --release
     done
 
@@ -46,19 +46,19 @@ main() {
 
 [dependencies.std]
 default-features = false
-features = ["compiler-builtins", "naive_ralloc"]
+features = ["naive_ralloc"]
 path = "/project"
-stage = 1
+stage = 2
 
 [dependencies.test]
 path = "/project/test"
-stage = 2
+stage = 3
 EOF
 
     cross test \
           --target $TARGET \
           --no-default-features \
-          --features "naive_ralloc"
+          --features naive_ralloc
 
     set +x
     pushd target/$TARGET/release/examples

--- a/docker/aarch64-unknown-linux-steed.json
+++ b/docker/aarch64-unknown-linux-steed.json
@@ -11,18 +11,19 @@
     "env": "steed",
     "executables": true,
     "has-elf-tls": true,
-    "linker-is-gnu": true,
+    "linker": "ld.lld",
+    "linker-flavor": "ld",
     "llvm-target": "aarch64-unknown-linux",
     "max-atomic-width": 128,
     "os": "linux",
     "panic-strategy": "abort",
-    "pre-link-args": [
-        "-Wl,--as-needed",
-        "-Wl,--build-id=none",
-        "-Wl,-z,noexecstack",
-        "-nostartfiles",
-        "-static"
-    ],
+    "pre-link-args": {
+        "gcc": [
+            "-Wl,--as-needed",
+            "-Wl,-z,noexecstack",
+            "-nostartfiles"
+        ]
+    },
     "target-endian": "little",
     "target-family": "unix",
     "target-pointer-width": "64",

--- a/docker/aarch64-unknown-linux-steed/Dockerfile
+++ b/docker/aarch64-unknown-linux-steed/Dockerfile
@@ -7,19 +7,16 @@ RUN apt-get update && \
     libc6-dev && \
     mkdir /json
 
+COPY xargo.sh /
+RUN bash /xargo.sh
+
+COPY lld.sh /
+RUN bash /lld.sh
+
 COPY qemu.sh /
-RUN apt-get install -y --no-install-recommends \
-    gcc-aarch64-linux-gnu && \
-    bash /qemu.sh 2.8.0 aarch64
+RUN bash /qemu.sh 2.8.0 aarch64
 
 COPY aarch64-unknown-linux-steed.json /json
 
-RUN apt-get install -y --no-install-recommends \
-    curl && \
-    curl -LSfs http://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.3.5 --target x86_64-unknown-linux-gnu --to /usr/bin && \
-    apt-get purge --auto-remove -y curl
-
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_STEED_LINKER=aarch64-linux-gnu-gcc \
-    RUST_TARGET_PATH=/json \
+ENV RUST_TARGET_PATH=/json \
     RUST_TEST_THREADS=1

--- a/docker/arm-unknown-linux-steedeabi.json
+++ b/docker/arm-unknown-linux-steedeabi.json
@@ -12,18 +12,19 @@
     "executables": true,
     "features": "+v6",
     "has-elf-tls": true,
-    "linker-is-gnu": true,
+    "linker": "ld.lld",
+    "linker-flavor": "ld",
     "llvm-target": "arm-unknown-linux-eabi",
     "max-atomic-width": 64,
     "os": "linux",
     "panic-strategy": "abort",
-    "pre-link-args": [
-        "-Wl,--as-needed",
-        "-Wl,--build-id=none",
-        "-Wl,-z,noexecstack",
-        "-nostartfiles",
-        "-static"
-    ],
+    "pre-link-args": {
+        "gcc": [
+            "-Wl,--as-needed",
+            "-Wl,-z,noexecstack",
+            "-nostartfiles"
+        ]
+    },
     "target-endian": "little",
     "target-family": "unix",
     "target-pointer-width": "32",

--- a/docker/arm-unknown-linux-steedeabi/Dockerfile
+++ b/docker/arm-unknown-linux-steedeabi/Dockerfile
@@ -7,20 +7,16 @@ RUN apt-get update && \
     libc6-dev && \
     mkdir /json
 
+COPY xargo.sh /
+RUN bash /xargo.sh
+
+COPY lld.sh /
+RUN bash /lld.sh
+
 COPY qemu.sh /
 RUN bash /qemu.sh 2.8.0 arm
 
-RUN apt-get install -y --no-install-recommends \
-    gcc-arm-linux-gnueabi
-
 COPY arm-unknown-linux-steedeabi.json /json
 
-RUN apt-get install -y --no-install-recommends \
-    curl && \
-    curl -LSfs http://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.3.5 --target x86_64-unknown-linux-gnu --to /usr/bin && \
-    apt-get purge --auto-remove -y curl
-
-ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_STEEDEABI_LINKER=arm-linux-gnueabi-gcc \
-    RUST_TARGET_PATH=/json \
+ENV RUST_TARGET_PATH=/json \
     RUST_TEST_THREADS=1

--- a/docker/arm-unknown-linux-steedeabihf.json
+++ b/docker/arm-unknown-linux-steedeabihf.json
@@ -12,18 +12,19 @@
     "executables": true,
     "features": "+v6,+vfp2",
     "has-elf-tls": true,
-    "linker-is-gnu": true,
+    "linker": "ld.lld",
+    "linker-flavor": "ld",
     "llvm-target": "arm-unknown-linux-eabihf",
     "max-atomic-width": 64,
     "os": "linux",
     "panic-strategy": "abort",
-    "pre-link-args": [
-        "-Wl,--as-needed",
-        "-Wl,--build-id=none",
-        "-Wl,-z,noexecstack",
-        "-nostartfiles",
-        "-static"
-    ],
+    "pre-link-args": {
+        "gcc": [
+            "-Wl,--as-needed",
+            "-Wl,-z,noexecstack",
+            "-nostartfiles"
+        ]
+    },
     "target-endian": "little",
     "target-family": "unix",
     "target-pointer-width": "32",

--- a/docker/arm-unknown-linux-steedeabihf/Dockerfile
+++ b/docker/arm-unknown-linux-steedeabihf/Dockerfile
@@ -7,20 +7,16 @@ RUN apt-get update && \
     libc6-dev && \
     mkdir /json
 
+COPY xargo.sh /
+RUN bash /xargo.sh
+
+COPY lld.sh /
+RUN bash /lld.sh
+
 COPY qemu.sh /
 RUN bash /qemu.sh 2.8.0 arm
 
-RUN apt-get install -y --no-install-recommends \
-    gcc-arm-linux-gnueabihf
-
 COPY arm-unknown-linux-steedeabihf.json /json
 
-RUN apt-get install -y --no-install-recommends \
-    curl && \
-    curl -LSfs http://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.3.5 --target x86_64-unknown-linux-gnu --to /usr/bin && \
-    apt-get purge --auto-remove -y curl
-
-ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_STEEDEABIHF_LINKER=arm-linux-gnueabihf-gcc \
-    RUST_TARGET_PATH=/json \
+ENV RUST_TARGET_PATH=/json \
     RUST_TEST_THREADS=1

--- a/docker/armv7-unknown-linux-steedeabihf.json
+++ b/docker/armv7-unknown-linux-steedeabihf.json
@@ -12,18 +12,19 @@
     "executables": true,
     "features": "+v7,+vfp3,+d16,+thumb2,-neon",
     "has-elf-tls": true,
-    "linker-is-gnu": true,
+    "linker": "ld.lld",
+    "linker-flavor": "ld",
     "llvm-target": "armv7-unknown-linux-eabihf",
     "max-atomic-width": 64,
     "os": "linux",
     "panic-strategy": "abort",
-    "pre-link-args": [
-        "-Wl,--as-needed",
-        "-Wl,--build-id=none",
-        "-Wl,-z,noexecstack",
-        "-nostartfiles",
-        "-static"
-    ],
+    "pre-link-args": {
+        "gcc": [
+            "-Wl,--as-needed",
+            "-Wl,-z,noexecstack",
+            "-nostartfiles"
+        ]
+    },
     "target-endian": "little",
     "target-family": "unix",
     "target-pointer-width": "32",

--- a/docker/armv7-unknown-linux-steedeabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-steedeabihf/Dockerfile
@@ -7,20 +7,16 @@ RUN apt-get update && \
     libc6-dev && \
     mkdir /json
 
+COPY xargo.sh /
+RUN bash /xargo.sh
+
+COPY lld.sh /
+RUN bash /lld.sh
+
 COPY qemu.sh /
 RUN bash /qemu.sh 2.8.0 arm
 
-RUN apt-get install -y --no-install-recommends \
-    gcc-arm-linux-gnueabihf
-
 COPY armv7-unknown-linux-steedeabihf.json /json
 
-RUN apt-get install -y --no-install-recommends \
-    curl && \
-    curl -LSfs http://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.3.5 --target x86_64-unknown-linux-gnu --to /usr/bin && \
-    apt-get purge --auto-remove -y curl
-
-ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_STEEDEABIHF_LINKER=arm-linux-gnueabihf-gcc \
-    RUST_TARGET_PATH=/json \
+ENV RUST_TARGET_PATH=/json \
     RUST_TEST_THREADS=1

--- a/docker/i686-unknown-linux-steed.json
+++ b/docker/i686-unknown-linux-steed.json
@@ -5,19 +5,20 @@
     "env": "steed",
     "executables": true,
     "has-elf-tls": true,
-    "linker-is-gnu": true,
+    "linker": "ld.lld",
+    "linker-flavor": "ld",
     "llvm-target": "i686-unknown-linux",
     "max-atomic-width": 64,
     "os": "linux",
     "panic-strategy": "abort",
-    "pre-link-args": [
-        "-Wl,--as-needed",
-        "-Wl,--build-id=none",
-        "-Wl,-z,noexecstack",
-        "-m32",
-        "-nostartfiles",
-        "-static"
-    ],
+    "pre-link-args": {
+        "gcc": [
+            "-Wl,--as-needed",
+            "-Wl,-z,noexecstack",
+            "-m32",
+            "-nostartfiles"
+        ]
+    },
     "target-endian": "little",
     "target-family": "unix",
     "target-pointer-width": "32",

--- a/docker/i686-unknown-linux-steed/Dockerfile
+++ b/docker/i686-unknown-linux-steed/Dockerfile
@@ -7,15 +7,12 @@ RUN apt-get update && \
     libc6-dev && \
     mkdir /json
 
-RUN apt-get install -y --no-install-recommends \
-    gcc-multilib
+COPY xargo.sh /
+RUN bash /xargo.sh
+
+COPY lld.sh /
+RUN bash /lld.sh
 
 COPY i686-unknown-linux-steed.json /json
-
-RUN apt-get install -y --no-install-recommends \
-    curl && \
-    curl -LSfs http://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.3.5 --target x86_64-unknown-linux-gnu --to /usr/bin && \
-    apt-get purge --auto-remove -y curl
 
 ENV RUST_TARGET_PATH=/json

--- a/docker/lld.sh
+++ b/docker/lld.sh
@@ -1,0 +1,34 @@
+set -ex
+
+main() {
+    local dependencies=(
+        ca-certificates
+        curl
+    )
+
+    apt-get update
+    local purge_list=()
+    for dep in ${dependencies[@]}; do
+        if ! dpkg -L $dep; then
+            apt-get install --no-install-recommends -y $dep
+            purge_list+=( $dep )
+        fi
+    done
+
+    cat <<EOF >>/etc/apt/sources.list
+deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main
+deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main
+EOF
+
+    curl -L http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+    apt-get update
+    apt-get install --no-install-recommends -y lld-4.0
+    ln -s ld.lld-4.0 /usr/bin/ld.lld
+
+    # Clean up
+    apt-get purge --auto-remove -y ${purge_list[@]}
+
+    rm $0
+}
+
+main "${@}"

--- a/docker/mips-unknown-linux-steed.json
+++ b/docker/mips-unknown-linux-steed.json
@@ -5,18 +5,19 @@
     "env": "steed",
     "executables": true,
     "has-elf-tls": true,
-    "linker-is-gnu": true,
+    "linker": "ld.lld",
+    "linker-flavor": "ld",
     "llvm-target": "mips-unknown-linux",
     "max-atomic-width": 32,
     "os": "linux",
     "panic-strategy": "abort",
-    "pre-link-args": [
-        "-Wl,--as-needed",
-        "-Wl,--build-id=none",
-        "-Wl,-z,noexecstack",
-        "-nostartfiles",
-        "-static"
-    ],
+    "pre-link-args": {
+        "gcc": [
+            "-Wl,--as-needed",
+            "-Wl,-z,noexecstack",
+            "-nostartfiles"
+        ]
+    },
     "relocation-model": "static",
     "target-endian": "big",
     "target-family": "unix",

--- a/docker/mips-unknown-linux-steed/Dockerfile
+++ b/docker/mips-unknown-linux-steed/Dockerfile
@@ -7,19 +7,16 @@ RUN apt-get update && \
     libc6-dev && \
     mkdir /json
 
+COPY xargo.sh /
+RUN bash /xargo.sh
+
+COPY lld.sh /
+RUN bash /lld.sh
+
 COPY qemu.sh /
-RUN apt-get install -y --no-install-recommends \
-    gcc-mips-linux-gnu && \
-    bash /qemu.sh 2.8.0 mips
+RUN bash /qemu.sh 2.8.0 mips
 
 COPY mips-unknown-linux-steed.json /json
 
-RUN apt-get install -y --no-install-recommends \
-    curl && \
-    curl -LSfs http://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.3.5 --target x86_64-unknown-linux-gnu --to /usr/bin && \
-    apt-get purge --auto-remove -y curl
-
-ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_STEED_LINKER=mips-linux-gnu-gcc \
-    RUST_TARGET_PATH=/json \
+ENV RUST_TARGET_PATH=/json \
     RUST_TEST_THREADS=1

--- a/docker/mipsel-unknown-linux-steed.json
+++ b/docker/mipsel-unknown-linux-steed.json
@@ -5,18 +5,19 @@
     "env": "steed",
     "executables": true,
     "has-elf-tls": true,
-    "linker-is-gnu": true,
+    "linker": "ld.lld",
+    "linker-flavor": "ld",
     "llvm-target": "mipsel-unknown-linux",
     "max-atomic-width": 32,
     "os": "linux",
     "panic-strategy": "abort",
-    "pre-link-args": [
-        "-Wl,--as-needed",
-        "-Wl,--build-id=none",
-        "-Wl,-z,noexecstack",
-        "-nostartfiles",
-        "-static"
-    ],
+    "pre-link-args": {
+        "gcc": [
+            "-Wl,--as-needed",
+            "-Wl,-z,noexecstack",
+            "-nostartfiles"
+        ]
+    },
     "relocation-model": "static",
     "target-endian": "little",
     "target-family": "unix",

--- a/docker/mipsel-unknown-linux-steed/Dockerfile
+++ b/docker/mipsel-unknown-linux-steed/Dockerfile
@@ -7,19 +7,16 @@ RUN apt-get update && \
     libc6-dev && \
     mkdir /json
 
+COPY xargo.sh /
+RUN bash /xargo.sh
+
+COPY lld.sh /
+RUN bash /lld.sh
+
 COPY qemu.sh /
-RUN apt-get install -y --no-install-recommends \
-    gcc-mipsel-linux-gnu && \
-    bash /qemu.sh 2.8.0 mipsel
+RUN bash /qemu.sh 2.8.0 mipsel
 
 COPY mipsel-unknown-linux-steed.json /json
 
-RUN apt-get install -y --no-install-recommends \
-    curl && \
-    curl -LSfs http://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.3.5 --target x86_64-unknown-linux-gnu --to /usr/bin && \
-    apt-get purge --auto-remove -y curl
-
-ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_STEED_LINKER=mipsel-linux-gnu-gcc \
-    RUST_TARGET_PATH=/json \
+ENV RUST_TARGET_PATH=/json \
     RUST_TEST_THREADS=1

--- a/docker/powerpc-unknown-linux-steed.json
+++ b/docker/powerpc-unknown-linux-steed.json
@@ -13,7 +13,7 @@
         "gcc": [
             "-Wl,--as-needed",
             "-Wl,-z,noexecstack",
-            "-m64",
+            "-m32",
             "-nostartfiles"
         ]
     },

--- a/docker/powerpc-unknown-linux-steed.json
+++ b/docker/powerpc-unknown-linux-steed.json
@@ -4,19 +4,19 @@
     "env": "steed",
     "executables": true,
     "has-elf-tls": true,
-    "linker-is-gnu": true,
+    "linker-flavor": "gcc",
     "llvm-target": "powerpc-unknown-linux",
     "max-atomic-width": 32,
     "os": "linux",
     "panic-strategy": "abort",
-    "pre-link-args": [
-        "-Wl,--as-needed",
-        "-Wl,--build-id=none",
-        "-Wl,-z,noexecstack",
-        "-m32",
-        "-nostartfiles",
-        "-static"
-    ],
+    "pre-link-args": {
+        "gcc": [
+            "-Wl,--as-needed",
+            "-Wl,-z,noexecstack",
+            "-m64",
+            "-nostartfiles"
+        ]
+    },
     "target-endian": "big",
     "target-family": "unix",
     "target-pointer-width": "32",

--- a/docker/powerpc-unknown-linux-steed/Dockerfile
+++ b/docker/powerpc-unknown-linux-steed/Dockerfile
@@ -7,18 +7,15 @@ RUN apt-get update && \
     libc6-dev && \
     mkdir /json
 
+COPY xargo.sh /
+RUN bash /xargo.sh
+
 COPY qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     gcc-powerpc-linux-gnu && \
     bash /qemu.sh 2.7.1 ppc
 
 COPY powerpc-unknown-linux-steed.json /json
-
-RUN apt-get install -y --no-install-recommends \
-    curl && \
-    curl -LSfs http://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.3.5 --target x86_64-unknown-linux-gnu --to /usr/bin && \
-    apt-get purge --auto-remove -y curl
 
 ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_STEED_LINKER=powerpc-linux-gnu-gcc \
     RUST_TARGET_PATH=/json \

--- a/docker/powerpc64-unknown-linux-steed.json
+++ b/docker/powerpc64-unknown-linux-steed.json
@@ -5,19 +5,19 @@
     "env": "steed",
     "executables": true,
     "has-elf-tls": true,
-    "linker-is-gnu": true,
+    "linker-flavor": "gcc",
     "llvm-target": "powerpc64-unknown-linux",
     "max-atomic-width": 64,
     "os": "linux",
     "panic-strategy": "abort",
-    "pre-link-args": [
-        "-Wl,--as-needed",
-        "-Wl,--build-id=none",
-        "-Wl,-z,noexecstack",
-        "-m64",
-        "-nostartfiles",
-        "-static"
-    ],
+    "pre-link-args": {
+        "gcc": [
+            "-Wl,--as-needed",
+            "-Wl,-z,noexecstack",
+            "-m64",
+            "-nostartfiles"
+        ]
+    },
     "target-endian": "big",
     "target-family": "unix",
     "target-pointer-width": "64",

--- a/docker/powerpc64-unknown-linux-steed/Dockerfile
+++ b/docker/powerpc64-unknown-linux-steed/Dockerfile
@@ -7,18 +7,15 @@ RUN apt-get update && \
     libc6-dev && \
     mkdir /json
 
+COPY xargo.sh /
+RUN bash /xargo.sh
+
 COPY qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     gcc-powerpc64-linux-gnu && \
     bash /qemu.sh 2.7.1 ppc64
 
 COPY powerpc64-unknown-linux-steed.json /json
-
-RUN apt-get install -y --no-install-recommends \
-    curl && \
-    curl -LSfs http://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.3.5 --target x86_64-unknown-linux-gnu --to /usr/bin && \
-    apt-get purge --auto-remove -y curl
 
 ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_STEED_LINKER=powerpc64-linux-gnu-gcc \
     RUST_TARGET_PATH=/json \

--- a/docker/powerpc64le-unknown-linux-steed.json
+++ b/docker/powerpc64le-unknown-linux-steed.json
@@ -5,19 +5,19 @@
     "env": "steed",
     "executables": true,
     "has-elf-tls": true,
-    "linker-is-gnu": true,
+    "linker-flavor": "gcc",
     "llvm-target": "powerpc64le-unknown-linux",
     "max-atomic-width": 64,
     "os": "linux",
     "panic-strategy": "abort",
-    "pre-link-args": [
-        "-Wl,--as-needed",
-        "-Wl,--build-id=none",
-        "-Wl,-z,noexecstack",
-        "-m64",
-        "-nostartfiles",
-        "-static"
-    ],
+    "pre-link-args": {
+        "gcc": [
+            "-Wl,--as-needed",
+            "-Wl,-z,noexecstack",
+            "-m64",
+            "-nostartfiles"
+        ]
+    },
     "target-endian": "little",
     "target-family": "unix",
     "target-pointer-width": "64",

--- a/docker/powerpc64le-unknown-linux-steed/Dockerfile
+++ b/docker/powerpc64le-unknown-linux-steed/Dockerfile
@@ -7,18 +7,15 @@ RUN apt-get update && \
     libc6-dev && \
     mkdir /json
 
+COPY xargo.sh /
+RUN bash /xargo.sh
+
 COPY qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     gcc-powerpc64le-linux-gnu && \
     bash /qemu.sh 2.7.1 ppc64le
 
 COPY powerpc64le-unknown-linux-steed.json /json
-
-RUN apt-get install -y --no-install-recommends \
-    curl && \
-    curl -LSfs http://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.3.5 --target x86_64-unknown-linux-gnu --to /usr/bin && \
-    apt-get purge --auto-remove -y curl
 
 ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_STEED_LINKER=powerpc64le-linux-gnu-gcc \
     RUST_TARGET_PATH=/json \

--- a/docker/x86_64-unknown-linux-steed.json
+++ b/docker/x86_64-unknown-linux-steed.json
@@ -5,19 +5,20 @@
     "env": "steed",
     "executables": true,
     "has-elf-tls": true,
-    "linker-is-gnu": true,
+    "linker": "ld.lld",
+    "linker-flavor": "ld",
     "llvm-target": "x86_64-unknown-linux",
     "max-atomic-width": 64,
     "os": "linux",
     "panic-strategy": "abort",
-    "pre-link-args": [
-        "-Wl,--as-needed",
-        "-Wl,--build-id=none",
-        "-Wl,-z,noexecstack",
-        "-m64",
-        "-nostartfiles",
-        "-static"
-    ],
+    "pre-link-args": {
+        "gcc": [
+            "-Wl,--as-needed",
+            "-Wl,-z,noexecstack",
+            "-m64",
+            "-nostartfiles"
+        ]
+    },
     "target-endian": "little",
     "target-family": "unix",
     "target-pointer-width": "64",

--- a/docker/x86_64-unknown-linux-steed/Dockerfile
+++ b/docker/x86_64-unknown-linux-steed/Dockerfile
@@ -7,12 +7,12 @@ RUN apt-get update && \
     libc6-dev && \
     mkdir /json
 
-COPY x86_64-unknown-linux-steed.json /json
+COPY xargo.sh /
+RUN bash /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
-    curl && \
-    curl -LSfs http://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.3.5 --target x86_64-unknown-linux-gnu --to /usr/bin && \
-    apt-get purge --auto-remove -y curl
+COPY lld.sh /
+RUN bash /lld.sh
+
+COPY x86_64-unknown-linux-steed.json /json
 
 ENV RUST_TARGET_PATH=/json

--- a/docker/xargo.sh
+++ b/docker/xargo.sh
@@ -1,0 +1,32 @@
+set -ex
+
+main() {
+    local tag=v0.3.6
+    local dependencies=(
+        ca-certificates
+        curl
+    )
+
+    apt-get update
+    local purge_list=()
+    for dep in ${dependencies[@]}; do
+        if ! dpkg -L $dep; then
+            apt-get install --no-install-recommends -y $dep
+            purge_list+=( $dep )
+        fi
+    done
+
+    curl -LSfs http://japaric.github.io/trust/install.sh | \
+        sh -s -- \
+           --git japaric/xargo \
+           --tag $tag \
+           --target x86_64-unknown-linux-gnu \
+           --to /usr/bin
+
+    # Clean up
+    apt-get purge --auto-remove -y ${purge_list[@]}
+
+    rm $0
+}
+
+main "${@}"


### PR DESCRIPTION
with this you can easily cross compile `steed` programs to the ARM, AArch64,
i686, MIPS, MIPSel and x86_64 targets without having to install a cross C
toolchain for each :tada:

We are not using lld for PowerPC because it seems to have bugs -- I get weird
linker errors about missing symbols that seem unrelated to Rust.

closes #24