### PR TITLE
Remove references to core::num::{Zero, One}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@
 #![feature(try_from)]
 #![feature(unicode)]
 #![feature(unique)]
-#![feature(zero_one)]
 #![no_std]
 
 #![stable(feature = "rust1", since = "1.0.0")]

--- a/src/libc/mod.rs
+++ b/src/libc/mod.rs
@@ -67,7 +67,7 @@ pub type mode_t = u32;
 #[cfg(issue = "22")]
 pub const EAI_SYSTEM: c_int = -11;
 
-// Rust 1.15.0
+// Rust 1.16.0
 // src/liblibc/src/unix/notbsd/linux/musl/mod.rs
 pub const PTHREAD_STACK_MIN: size_t = 2048;
 

--- a/src/num.rs
+++ b/src/num.rs
@@ -17,9 +17,6 @@
 #![allow(missing_docs)]
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[allow(deprecated)]
-pub use core::num::{Zero, One};
-#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::num::{FpCategory, ParseIntError, ParseFloatError, TryFromIntError};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::num::Wrapping;


### PR DESCRIPTION
It got removed from Rust tree in commit c903ac64e58241a71ec42e791b0cc1451ffc3840